### PR TITLE
Handle departures exactly the same as a previous arrival

### DIFF
--- a/src/ConnectionScanner.php
+++ b/src/ConnectionScanner.php
@@ -53,7 +53,7 @@ class ConnectionScanner {
         foreach ($this->timetable as $connection) {
             list($origin, $destination, $departureTime, $arrivalTime) = $connection;
 
-            $canGetToThisConnection = array_key_exists($origin, $arrivals) && $departureTime > $arrivals[$origin];
+            $canGetToThisConnection = array_key_exists($origin, $arrivals) && $departureTime >= $arrivals[$origin];
             $thisConnectionIsBetter = !array_key_exists($destination, $arrivals) || $arrivals[$destination] > $arrivalTime;
 
             if ($canGetToThisConnection && $thisConnectionIsBetter) {


### PR DESCRIPTION
When there are no time gaps between station arrival and departure to the next station route finding fails.